### PR TITLE
Plybook added for layup visualization

### DIFF
--- a/fusedwind/turbine/layup.py
+++ b/fusedwind/turbine/layup.py
@@ -626,6 +626,9 @@ class BladeLayup(object):
                 r = reg_type['%s%02d' % (rtype,rset[0])] 
                 plt.figure()
                 plt.title(rtype.upper() + ' ' + str(rset))
+                # draw station lines
+                for s in self.s:
+                    plt.plot([self.s, self.s], [0, maxthick], 'k', linewidth=0.5)
                 t = np.zeros_like(self.s)
                 for k, l in r.layers.iteritems():
                     mat_name = k[:-2]

--- a/fusedwind/turbine/layup.py
+++ b/fusedwind/turbine/layup.py
@@ -566,6 +566,9 @@ class BladeLayup(object):
         for di, dk in enumerate(sorted(self.DPs, reverse = True)):
             plt.plot(self.s, self.DPs[dk].arc, label = dk[-2:]) 
         plt.legend(loc = 'best', prop={'size':6}, bbox_to_anchor=(1, 1))
+        # draw station lines
+        for s in self.s:
+            plt.plot([self.s, self.s], [-1, 1], 'k', linewidth=0.5)
         pb.savefig() # save fig to plybook
         
         # create material color dict (necessary for the case that materials list
@@ -593,10 +596,8 @@ class BladeLayup(object):
                 rv.init_thicknesses()
                 rthicks.append(rv.thick_matrix)
                 rmaxthicks.append(np.sum(rv.thick_max))
-                
             # maximum thickness of sets
             rmaxthick = np.max(rmaxthicks)
-            
             # check for identic regions
             rsets = []
             for rt0 in rthicks:

--- a/fusedwind/turbine/layup.py
+++ b/fusedwind/turbine/layup.py
@@ -551,7 +551,6 @@ class BladeLayup(object):
         
         :param filename: name of the PDF
         :param vmode: 'stack' or 'explode' visualization of layup
-        Note: 'stack' visualisation includes ply-drops to zero, 'explode' not.
         '''
         
         import matplotlib.pylab as plt
@@ -636,9 +635,9 @@ class BladeLayup(object):
                     mat_name = k[:-2]
                     mat_count = k[-2:]
                     if vmode == 'stack':
-                        # draw layer box incl ply-drops to zero
+                        # draw layer box
                         plt.plot(self.s, t + l.thickness, 'k')
-                        # draw layer thickness distro incl ply-drops to zero
+                        # draw layer thickness distro
                         plt.fill_between(self.s, t, t + l.thickness,
                                          color=cm_dict[mat_name],
                                          label = mat_name if int(mat_count) == 0 else "_nolegend_")
@@ -659,74 +658,44 @@ class BladeLayup(object):
                             drop_prev = drop
                         if len(drops) == 1: 
                             drops.append(len(l.thickness)-1)
-                            
                         max_thick = np.max(l.thickness)
-                        bound_col= 'k'
-                        # draw layer box excl ply-drops to zero
+                        # draw layer box
                         for di in range(len(drops)-1):
-                            
-                            
+                            # draw box per layer
                             north_west = [self.s[drops[di]], t[drops[di]] + max_thick]
                             south_west = [self.s[drops[di]], t[drops[di]]]
                             north_east = [self.s[drops[di+1]], t[drops[di+1]]+ max_thick]
                             south_east = [self.s[drops[di+1]], t[drops[di+1]]]
-                            # draw ramp up
-                            if drops[di] > 0:
-                                #plt.plot([self.s[drops[di]-1], self.s[drops[di]]],
-                                #         [t[drops[di]], t[drops[di]] + max_thick], bound_col)
-                                #plt.plot([self.s[drops[di]-1], self.s[drops[di]]],
-                                #         [t[drops[di]], t[drops[di]]], bound_col)
+                            if drops[di] > 0: # we have a plydrop up
+                                north_west = [self.s[drops[di]-1], t[drops[di]] + max_thick]
                                 south_west = [self.s[drops[di]-1], t[drops[di]]]
                                 south_south_west = [self.s[drops[di]], t[drops[di]]]
                                 north_mid_west = [self.s[drops[di]], (t + l.thickness)[drops[di]]]
-                                
+                                # draw layer thickness distro drop
                                 ax1.add_patch(patches.Polygon(
-                                [south_west, north_mid_west, south_south_west],
-                                                            linewidth=0,
-                                                              facecolor=cm_dict[mat_name]))
-
-                            if drops[di+1] < len(self.s)-1:
-                                
+                                    [south_west, north_mid_west, south_south_west],
+                                    linewidth=0,facecolor=cm_dict[mat_name]))
+                            if drops[di+1] < len(self.s)-1: # we have a plydrop down
                                 south_east = [self.s[drops[di+1]+1], t[drops[di+1]]]
-                                
-                                #plt.plot([self.s[drops[di]], self.s[drops[di]]],
-                                #         [t[drops[di]], t[drops[di]] + max_thick], bound_col)
+                                north_east = [self.s[drops[di+1]+1], t[drops[di+1]]+ max_thick]
                                 south_south_east = [self.s[drops[di+1]], t[drops[di+1]]]
                                 north_mid_east = [self.s[drops[di+1]], (t + l.thickness)[drops[di+1]]]
+                                # draw layer thickness distro drop
                                 ax1.add_patch(patches.Polygon(
-                                [north_mid_east, south_east, south_south_east],
-                                                            linewidth=0,
-                                                              facecolor=cm_dict[mat_name]))
-        
-                                
+                                    [north_mid_east, south_east, south_south_east],
+                                    linewidth=0,facecolor=cm_dict[mat_name]))
                             ax1.add_patch(patches.Polygon(
                                 [south_west, north_west, north_east, south_east],
-                                                              fill=False))
-                            # draw ramp down
-                            #if drops[di+1] < len(self.s)-1:
-                                #plt.plot([self.s[drops[di+1]+1], self.s[drops[di+1]]],
-                                #         [t[drops[di+1]], t[drops[di+1]] + max_thick], bound_col)
-                                #plt.plot([self.s[drops[di+1]+1], self.s[drops[di+1]]],
-                                #         [t[drops[di+1]], t[drops[di+1]]], bound_col)
-                            #else:
-                                #plt.plot([self.s[drops[di+1]], self.s[drops[di+1]]],
-                                #         [t[drops[di+1]], t[drops[di+1]] + max_thick], bound_col)
-                            # draw bottom line
-                            #plt.plot(self.s[drops[di]:drops[di+1]+1],
-                                     #t[drops[di]:drops[di+1]+1], bound_col)
-                            # draw top line
-                            #plt.plot(self.s[drops[di]:drops[di+1]+1],
-                                     #t[drops[di]:drops[di+1]+1] + max_thick, bound_col)
-                        # draw layer thickness distro excl ply-drops to zero
+                                fill=False))
+                        # draw layer thickness distro
                         plt.fill_between(self.s, t, t + l.thickness,
-                                         where=t < t + l.thickness,
-                                         color=cm_dict[mat_name],
-                                         label = mat_name if int(mat_count) == 0 else "_nolegend_")
+                            where=t < t + l.thickness,
+                            color=cm_dict[mat_name],
+                            label = mat_name if int(mat_count) == 0 else "_nolegend_")
                         t = t + max_thick
                 plt.ylim([0, maxthick]) # set all plot limits to maxthickness
                 plt.xlim([0, 1])
                 plt.legend(loc = 'best')
-                #plt.show()
                 pb.savefig(fig1) # save fig to plybook
         
         rsets, rmaxthick = _region_sets(self.regions)

--- a/fusedwind/turbine/layup.py
+++ b/fusedwind/turbine/layup.py
@@ -323,7 +323,7 @@ class Region(object):
         '''
         dubl = 0
         for k in self.layers.iterkeys():
-            if name in k:
+            if name == k[:-2]:
                 dubl += 1
 
         lname = '%s%02d' % (name, dubl)

--- a/fusedwind/turbine/layup.py
+++ b/fusedwind/turbine/layup.py
@@ -464,7 +464,7 @@ class BladeLayup(object):
         for their existence in the materials dict. Also initilized objects are 
         checked if they have unset values.
         '''
-        print('Starting consistency check of BladeLeayup.')
+        print('Starting consistency check of BladeLayup.')
         #  check BladeLayup attributes
         for attr, val in self.__dict__.iteritems():
             if val is None:

--- a/fusedwind/turbine/structure.py
+++ b/fusedwind/turbine/structure.py
@@ -9,6 +9,7 @@ from openmdao.core.problem import Problem
 from openmdao.api import IndepVarComp
 
 from fusedwind.turbine.geometry import FFDSpline
+from collections import OrderedDict
 
 try:
     from PGL.components.airfoil import AirfoilShape
@@ -80,7 +81,10 @@ def read_bladestructure(filebase):
         materials = first_line
     if version >= 1:
         materials = fid.readline().split()[1:]
-    st3d['materials'] = {name:i for i, name in enumerate(materials)}
+    #st3d['materials'] = {name:i for i, name in enumerate(materials)}
+    st3d['materials'] = OrderedDict()
+    for i, name in enumerate(materials):
+        st3d['materials'][name] = i
     data = np.loadtxt(fid)
     st3d['matprops'] = data
 

--- a/fusedwind/turbine/test/test_layup.py
+++ b/fusedwind/turbine/test/test_layup.py
@@ -415,6 +415,12 @@ class LayupTests(unittest.TestCase):
     
     def test_check_consistency(self):
         self.assertEqual(self.bl._warns, 0, None)
+        
+    def test_print_plybook_explode(self):
+        self.bl.print_plybook(filename = 'plybook_explode', vmode = 'explode')
+    
+    def test_print_plybook_stack(self):
+        self.bl.print_plybook(filename = 'plybook_stack', vmode = 'stack')
     
     def test_check_consistency_incorrect(self):
         self.bl_inc = configure_incorrect()


### PR DESCRIPTION
While parameterizing a blade from scratch it is useful to have a visual feedback about the layup. Therefore, two plybook print options were added: 'explode' view mode and 'stack' view mode.
Note that the 'explode' mode does not yet show ply-drops from ant to zero thickness.