### PR TITLE
Blade structure: add output with x-sec material thickness to avoid overlapping regions at TE

### DIFF
--- a/fusedwind/turbine/structure.py
+++ b/fusedwind/turbine/structure.py
@@ -680,9 +680,10 @@ class ComputeDPsParam2(object):
         DPs[:, 0] = -1.
         DPs[:, -1] = 1.
 
-        # extra TE regions
-        DPs[:, 1] = -0.99
-        DPs[:, -2] = 0.99
+        # set extra TE regions if user hasn't specified anything
+        if (DPs[:, 1] == 0.).all():
+            DPs[:, 1] = -0.99
+            DPs[:, -2] = 0.99
 
         for i in range(self.ni):
             af = self.afs[i]
@@ -842,6 +843,7 @@ class ComputeDPsParam2(object):
             for d in DP:
                 plt.plot(d[2], d[0], 'ro')
 
+        self.DPs_xyz = np.asarray(DPs)
         #plt.show()
 
 


### PR DESCRIPTION
added `thickness_diff` to the `BladeStructureProperties`class. the output contains the difference between the cross-section thickness and total material thickness at each DP along the surface. this can be used as a constraint to ensure that the trailing edge material does not become thicker than there is room for in the blade.

The method is quite basic and assumes a symmetric layout of the DPs on lower and upper sides of the blade.